### PR TITLE
Expose allowed second factor types

### DIFF
--- a/src/Tests/Value/SecondFactorTypeTest.php
+++ b/src/Tests/Value/SecondFactorTypeTest.php
@@ -97,7 +97,7 @@ final class SecondFactorTypeTest extends TestCase
     {
         $this->assertTrue(
             (new SecondFactorType('yubikey'))->hasEqualOrHigherLoaComparedTo(new SecondFactorType('sms')),
-            'yubiykey >= sms'
+            'yubikey >= sms'
         );
         $this->assertTrue(
             (new SecondFactorType('sms'))->hasEqualOrHigherLoaComparedTo(new SecondFactorType('sms')),

--- a/src/Tests/Value/SecondFactorTypeTest.php
+++ b/src/Tests/Value/SecondFactorTypeTest.php
@@ -29,6 +29,7 @@ final class SecondFactorTypeTest extends TestCase
             'sms' => ['sms'],
             'tiqr' => ['tiqr'],
             'yubikey' => ['yubikey'],
+            'u2f' => ['u2f'],
             'biometric' => ['biometric'],
         ];
     }
@@ -86,6 +87,7 @@ final class SecondFactorTypeTest extends TestCase
         $this->assertTrue((new SecondFactorType('tiqr'))->isGssf());
         $this->assertTrue((new SecondFactorType('biometric'))->isBiometric());
         $this->assertTrue((new SecondFactorType('biometric'))->isGssf());
+        $this->assertTrue((new SecondFactorType('u2f'))->isU2f());
     }
 
     /**

--- a/src/Value/SecondFactorType.php
+++ b/src/Value/SecondFactorType.php
@@ -64,6 +64,14 @@ final class SecondFactorType implements JsonSerializable
     }
 
     /**
+     * @return string[]
+     */
+    public static function getAllowedSecondFactorTypes()
+    {
+        return array_keys(self::$loaLevelTypeMap);
+    }
+
+    /**
      * @param Loa $loa
      * @return bool
      */

--- a/src/Value/SecondFactorType.php
+++ b/src/Value/SecondFactorType.php
@@ -66,7 +66,7 @@ final class SecondFactorType implements JsonSerializable
     /**
      * @return string[]
      */
-    public static function getAllowedSecondFactorTypes()
+    public static function getAvailableSecondFactorTypes()
     {
         return array_keys(self::$loaLevelTypeMap);
     }


### PR DESCRIPTION
This makes it possible to use these types externally, for example for validation. 
We would like to validate second factor types in Middleware when offering an allowed second factor list through the Management API, see [119815553](https://www.pivotaltracker.com/story/show/119815553).