### PR TITLE
Feature/gssp add through config

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -99,6 +99,12 @@ services:
             - {} # OTP expiry interval
             - 0  # Maximum OTP requests
 
+    surfnet_stepup.service.second_factor_type:
+        public: false
+        class: Surfnet\StepupBundle\Service\SecondFactorTypeService
+        arguments:
+            - "%enabled_generic_second_factors%"
+
     surfnet_stepup.guzzle.gateway_api:
         public: false
         class: GuzzleHttp\Client

--- a/src/Service/SecondFactorTypeService.php
+++ b/src/Service/SecondFactorTypeService.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Service;
+
+
+use Surfnet\StepupBundle\Exception\DomainException;
+use Surfnet\StepupBundle\Value\GssfConfig;
+use Surfnet\StepupBundle\Value\Loa;
+use Surfnet\StepupBundle\Value\SecondFactorType;
+
+class SecondFactorTypeService
+{
+    /**
+     * @var array
+     */
+    private $loaLevelTypeMap = [
+        'sms' => Loa::LOA_2,
+        'yubikey' => Loa::LOA_3,
+        'u2f' => Loa::LOA_3,
+    ];
+
+    /**
+     * @var GssfConfig
+     */
+    private $gssfConfig;
+
+    /**
+     * @param array $gssfConfig
+     */
+    public function __construct(array $gssfConfig)
+    {
+        $this->gssfConfig = new GssfConfig($gssfConfig);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAvailableSecondFactorTypes()
+    {
+        return array_merge(
+            $this->gssfConfig->getSecondFactorTypes(),
+            array_keys($this->loaLevelTypeMap)
+        );
+    }
+
+    /**
+     * @param SecondFactorType $secondFactorType
+     * @param Loa $loa
+     * @return bool
+     */
+    public function canSatisfy(SecondFactorType $secondFactorType, Loa $loa)
+    {
+        return $loa->levelIsLowerOrEqualTo($this->getLevel($secondFactorType));
+    }
+
+    /**
+     * @param SecondFactorType $secondFactorType
+     * @param Loa $loa
+     * @return bool
+     */
+    public function isSatisfiedBy(SecondFactorType $secondFactorType, Loa $loa)
+    {
+        return $loa->levelIsHigherOrEqualTo($this->getLevel($secondFactorType));
+    }
+
+    /**
+     * @param SecondFactorType $secondFactorType
+     * @param SecondFactorTypeService|SecondFactorType $other
+     * @return bool
+     */
+    public function hasEqualOrHigherLoaComparedTo(SecondFactorType $secondFactorType, SecondFactorType $other)
+    {
+        return $this->getLevel($secondFactorType) >= $this->getLevel($other);
+    }
+
+    /**
+     * @param SecondFactorType $secondFactorType
+     * @param SecondFactorTypeService|SecondFactorType $other
+     * @return bool
+     */
+    public function hasEqualOrLowerLoaComparedTo(SecondFactorType $secondFactorType, SecondFactorType $other)
+    {
+        return $this->getLevel($secondFactorType) <= $this->getLevel($other);
+    }
+
+    /**
+     * @param SecondFactorType $secondFactorType
+     * @return int
+     */
+    public function getLevel(SecondFactorType $secondFactorType)
+    {
+        $loaMap = array_merge(
+            $this->loaLevelTypeMap,
+            $this->gssfConfig->getLoaMap()
+        );
+
+        if (array_key_exists($secondFactorType->getSecondFactorType(), $loaMap)) {
+            return $loaMap[$secondFactorType->getSecondFactorType()];
+        }
+        throw new DomainException(
+            sprintf(
+                'The Loa level of this type: %s can\'t be retrieved.',
+                $secondFactorType->getSecondFactorType()
+            )
+        );
+    }
+}

--- a/src/Tests/Service/SecondFactorTypeServiceTest.php
+++ b/src/Tests/Service/SecondFactorTypeServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Tests\Service;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
+use Surfnet\StepupBundle\Value\Loa;
+use Surfnet\StepupBundle\Value\SecondFactorType;
+
+class SecondFactorTypeServiceTest extends TestCase
+{
+    /**
+     * @group service
+     */
+    public function testItCanBeCreated()
+    {
+        $service = new SecondFactorTypeService([]);
+        $this->assertInstanceOf(SecondFactorTypeService::class, $service);
+    }
+
+    /**
+     * @group service
+     */
+    public function testItCanBeAskedForEnabledSecondFactorTypes()
+    {
+        $service = new SecondFactorTypeService($this->getAvailableSecondFactorTypes());
+        $types = $service->getAvailableSecondFactorTypes();
+        $this->assertInternalType('array', $types);
+        $this->assertContains('tiqr', $types);
+        $this->assertContains('biometric', $types);
+        $this->assertContains('sms', $types);
+        $this->assertContains('yubikey', $types);
+        $this->assertContains('u2f', $types);
+    }
+
+    /**
+     * @group service
+     */
+    public function testGetLevel()
+    {
+        $service = new SecondFactorTypeService($this->getAvailableSecondFactorTypes());
+        $this->assertEquals(3, $service->getLevel(new SecondFactorType('u2f')));
+        $this->assertEquals(2, $service->getLevel(new SecondFactorType('sms')));
+    }
+
+    /**
+     * @group service
+     * @expectedException \Surfnet\StepupBundle\Exception\DomainException
+     * @expectedExceptionMessage The Loa level of this type: u3f can't be retrieved.
+     */
+    public function testGetLevelCannotGetLevelOfNonExistingSecondFactorType()
+    {
+        $service = new SecondFactorTypeService($this->getAvailableSecondFactorTypes());
+        $service->getLevel(new SecondFactorType('u3f'));
+    }
+
+    /**
+     * @group service
+     */
+    public function testItCanBeAskedForEnabledSecondFactorTypesWhenNoGssfSet()
+    {
+        $service = new SecondFactorTypeService([]);
+        $types = $service->getAvailableSecondFactorTypes();
+        $this->assertInternalType('array', $types);
+        $this->assertContains('sms', $types);
+        $this->assertContains('yubikey', $types);
+        $this->assertContains('u2f', $types);
+    }
+
+    /**
+     * @group service
+     */
+    public function testItCanTestForSatisfactoryLoaLevel()
+    {
+        $service = new SecondFactorTypeService($this->getAvailableSecondFactorTypes());
+        $loa1 = new Loa(1, 'level-1');
+        $loa2 = new Loa(2, 'level-2');
+        $loa3 = new Loa(3, 'level-3');
+        $yubikey = new SecondFactorType('yubikey');
+        $tiqr = new SecondFactorType('tiqr');
+        $sms = new SecondFactorType('sms');
+        $biometric = new SecondFactorType('biometric');
+
+        $this->assertTrue($service->canSatisfy($yubikey, $loa1));
+        $this->assertTrue($service->canSatisfy($tiqr, $loa3));
+        $this->assertTrue($service->canSatisfy($biometric, $loa3));
+        $this->assertFalse($service->canSatisfy($sms, $loa3));
+        $this->assertTrue($service->canSatisfy($sms, $loa2));
+    }
+
+    /**
+     * @group service
+     */
+    public function testIsSatisfiedBy()
+    {
+        $service = new SecondFactorTypeService($this->getAvailableSecondFactorTypes());
+        $loa1 = new Loa(1, 'level-1');
+        $loa2 = new Loa(2, 'level-2');
+        $loa3 = new Loa(3, 'level-3');
+        $yubikey = new SecondFactorType('yubikey');
+        $sms = new SecondFactorType('sms');
+
+        $this->assertFalse($service->isSatisfiedBy($yubikey, $loa1));
+        $this->assertFalse($service->isSatisfiedBy($yubikey, $loa2));
+        $this->assertTrue($service->isSatisfiedBy($yubikey, $loa3));
+        $this->assertTrue($service->isSatisfiedBy($sms, $loa2));
+        $this->assertTrue($service->isSatisfiedBy($sms, $loa3));
+    }
+
+    /**
+     * @group service
+     */
+    public function testHasEqualOrHigherLoaComparedTo()
+    {
+        $service = new SecondFactorTypeService($this->getAvailableSecondFactorTypes());
+        $yubikey = new SecondFactorType('yubikey');
+        $tiqr = new SecondFactorType('tiqr');
+        $sms = new SecondFactorType('sms');
+        $biometric = new SecondFactorType('biometric');
+
+        $this->assertTrue($service->hasEqualOrHigherLoaComparedTo($tiqr, $biometric));
+        $this->assertTrue($service->hasEqualOrHigherLoaComparedTo($tiqr, $sms));
+        $this->assertTrue($service->hasEqualOrHigherLoaComparedTo($tiqr, $yubikey));
+        $this->assertTrue($service->hasEqualOrHigherLoaComparedTo($yubikey, $sms));
+        $this->assertTrue($service->hasEqualOrHigherLoaComparedTo($sms, $sms));
+    }
+
+    /**
+     * @group service
+     */
+    public function testHasEqualOrLowerLoaComparedTo()
+    {
+        $service = new SecondFactorTypeService($this->getAvailableSecondFactorTypes());
+        $yubikey = new SecondFactorType('yubikey');
+        $tiqr = new SecondFactorType('tiqr');
+        $sms = new SecondFactorType('sms');
+        $biometric = new SecondFactorType('biometric');
+
+        $this->assertTrue($service->hasEqualOrLowerLoaComparedTo($tiqr, $biometric));
+        $this->assertTrue($service->hasEqualOrLowerLoaComparedTo($sms, $tiqr));
+        $this->assertTrue($service->hasEqualOrLowerLoaComparedTo($sms, $biometric));
+        $this->assertTrue($service->hasEqualOrLowerLoaComparedTo($yubikey, $biometric));
+        $this->assertTrue($service->hasEqualOrLowerLoaComparedTo($sms, $sms));
+    }
+    
+    private function getAvailableSecondFactorTypes()
+    {
+        return [
+            'biometric' => [
+                'loa' => 3
+            ],
+            'tiqr' => [
+                'loa' => 3
+            ],
+        ];
+    }
+}

--- a/src/Tests/Value/SecondFactorTypeTest.php
+++ b/src/Tests/Value/SecondFactorTypeTest.php
@@ -59,17 +59,6 @@ final class SecondFactorTypeTest extends TestCase
 
     /**
      * @test
-     * @group value
-     *
-     * @expectedException \Surfnet\StepupBundle\Exception\DomainException
-     */
-    public function it_doesnt_accept_an_invalid_type()
-    {
-        new SecondFactorType('rosemary');
-    }
-
-    /**
-     * @test
      */
     public function its_equality_is_determined_by_its_type()
     {
@@ -88,28 +77,5 @@ final class SecondFactorTypeTest extends TestCase
         $this->assertTrue((new SecondFactorType('biometric'))->isBiometric());
         $this->assertTrue((new SecondFactorType('biometric'))->isGssf());
         $this->assertTrue((new SecondFactorType('u2f'))->isU2f());
-    }
-
-    /**
-     * @test
-     */
-    public function they_can_be_compared()
-    {
-        $this->assertTrue(
-            (new SecondFactorType('yubikey'))->hasEqualOrHigherLoaComparedTo(new SecondFactorType('sms')),
-            'yubikey >= sms'
-        );
-        $this->assertTrue(
-            (new SecondFactorType('sms'))->hasEqualOrHigherLoaComparedTo(new SecondFactorType('sms')),
-            'sms >= sms'
-        );
-        $this->assertTrue(
-            (new SecondFactorType('sms'))->hasEqualOrLowerLoaComparedTo(new SecondFactorType('yubikey')),
-            'sms <= yubikey'
-        );
-        $this->assertTrue(
-            (new SecondFactorType('sms'))->hasEqualOrLowerLoaComparedTo(new SecondFactorType('sms')),
-            'sms <= sms'
-        );
     }
 }

--- a/src/Value/GssfConfig.php
+++ b/src/Value/GssfConfig.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Value;
+
+
+class GssfConfig
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSecondFactorTypes()
+    {
+        return array_keys($this->config);
+    }
+
+    /**
+     * Flattens the config and returns key value pairs where the key is the SF type and the value is the LOA level
+     */
+    public function getLoaMap()
+    {
+        $loaMap = [];
+        foreach ($this->config as $key => $config) {
+            if (array_key_exists('loa', $config)) {
+                $loaMap[$key] = $config['loa'];
+            }
+        }
+        return $loaMap;
+    }
+}

--- a/src/Value/SecondFactorType.php
+++ b/src/Value/SecondFactorType.php
@@ -19,23 +19,10 @@
 namespace Surfnet\StepupBundle\Value;
 
 use JsonSerializable;
-use Surfnet\StepupBundle\Exception\DomainException;
 use Surfnet\StepupBundle\Exception\InvalidArgumentException;
 
-/**
- * @SuppressWarnings(PHPMD.TooManyMethods) All methods are relevant and simple.
- * @SuppressWarnings(PHPMD.TooManyPublicMethods) All methods are relevant and simple.
- */
 final class SecondFactorType implements JsonSerializable
 {
-    private static $loaLevelTypeMap = [
-        'sms'       => Loa::LOA_2,
-        'tiqr'      => Loa::LOA_2,
-        'yubikey'   => Loa::LOA_3,
-        'u2f'       => Loa::LOA_3,
-        'biometric' => Loa::LOA_3,
-    ];
-
     /**
      * @var string
      */
@@ -49,62 +36,7 @@ final class SecondFactorType implements JsonSerializable
         if (!is_string($type)) {
             throw InvalidArgumentException::invalidType('string', 'type', $type);
         }
-
-        if (!isset(self::$loaLevelTypeMap[$type])) {
-            throw new DomainException(
-                sprintf(
-                    "Invalid second factor type, got '%s', expected one of '%s'",
-                    $type,
-                    join(',', array_keys(self::$loaLevelTypeMap))
-                )
-            );
-        }
-
         $this->type = $type;
-    }
-
-    /**
-     * @return string[]
-     */
-    public static function getAvailableSecondFactorTypes()
-    {
-        return array_keys(self::$loaLevelTypeMap);
-    }
-
-    /**
-     * @param Loa $loa
-     * @return bool
-     */
-    public function canSatisfy(Loa $loa)
-    {
-        return $loa->levelIsLowerOrEqualTo($this->getLevel());
-    }
-
-    /**
-     * @param Loa $loa
-     * @return bool
-     */
-    public function isSatisfiedBy(Loa $loa)
-    {
-        return $loa->levelIsHigherOrEqualTo($this->getLevel());
-    }
-
-    /**
-     * @param self $other
-     * @return bool
-     */
-    public function hasEqualOrHigherLoaComparedTo(self $other)
-    {
-        return $this->getLevel() >= $other->getLevel();
-    }
-
-    /**
-     * @param self $other
-     * @return bool
-     */
-    public function hasEqualOrLowerLoaComparedTo(self $other)
-    {
-        return $this->getLevel() <= $other->getLevel();
     }
 
     /**
@@ -172,14 +104,6 @@ final class SecondFactorType implements JsonSerializable
     public function getSecondFactorType()
     {
         return $this->type;
-    }
-
-    /**
-     * @return int
-     */
-    public function getLevel()
-    {
-        return self::$loaLevelTypeMap[$this->type];
     }
 
     /**


### PR DESCRIPTION
This pull request is the Stepup bundle portion of making the generic second factors configurable through YML configuration. To do so, a service was introduced that reads the gssf configuration and helps the application with LOA related queries on a SecondFactorType value object.

This pull request is related to this [story](https://www.pivotaltracker.com/story/show/144698955)