### PR TITLE
Made SecondFactorTypeService a public service

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -100,7 +100,6 @@ services:
             - 0  # Maximum OTP requests
 
     surfnet_stepup.service.second_factor_type:
-        public: false
         class: Surfnet\StepupBundle\Service\SecondFactorTypeService
         arguments:
             - "%enabled_generic_second_factors%"


### PR DESCRIPTION
The gssf service needs to be serviceable publicly. This pull request fixes that.