### PR TITLE
Remove SURFisms

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -230,7 +230,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('domain')
                             ->info('Domain the cookie is scoped to')
-                            ->defaultValue('surfconext.nl')
+                            ->defaultValue('example.org')
                         ->end()
                         ->integerNode('expire')
                             ->info('Defines a specific number of seconds for when the browser should delete the cookie.')


### PR DESCRIPTION
- Updates the default value used for the locale cookie domain.

This change will result in new release of the Stepup-bundle, and should be rolled out to the users of this bundle.