### PR TITLE
Remove unused isTiqr and isBiometric methods

### DIFF
--- a/src/Tests/Value/SecondFactorTypeTest.php
+++ b/src/Tests/Value/SecondFactorTypeTest.php
@@ -72,8 +72,6 @@ final class SecondFactorTypeTest extends TestCase
     {
         $this->assertTrue((new SecondFactorType('sms'))->isSms());
         $this->assertTrue((new SecondFactorType('yubikey'))->isYubikey());
-        $this->assertTrue((new SecondFactorType('tiqr'))->isTiqr());
-        $this->assertTrue((new SecondFactorType('biometric'))->isBiometric());
         $this->assertTrue((new SecondFactorType('u2f'))->isU2f());
     }
 }

--- a/src/Value/SecondFactorType.php
+++ b/src/Value/SecondFactorType.php
@@ -67,25 +67,9 @@ final class SecondFactorType implements JsonSerializable
     /**
      * @return bool
      */
-    public function isTiqr()
-    {
-        return $this->type === 'tiqr';
-    }
-
-    /**
-     * @return bool
-     */
     public function isU2f()
     {
         return $this->type === 'u2f';
-    }
-
-    /**
-     * @return bool
-     */
-    public function isBiometric()
-    {
-        return $this->type === 'biometric';
     }
 
     /**


### PR DESCRIPTION
The SecondFactorType value object had an isTiqr and isBiometric methods
 which where no longer usefull and in use by any of the Stepup
 applications. Removing these methods makes the value object more robust
 as GSSP token identity checking should be done using the GsspService.