### PR TITLE
Implement error page redesign

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+# 2.1.0
+In this release error reporting is improved.
+
+## Improvements
+ * Implement error page redesign #47
+ * Improve art-code algorithm #48
 
 VERSION 2  DYNAMIC CONFIGURATION OF SECOND FACTOR TYPES
 =======================================================

--- a/README.md
+++ b/README.md
@@ -61,3 +61,33 @@ The locale switcher is a form that can be rendered with the help of a Twig funct
 <script type="text/javascript" src="{{ asset_url }}"></script>
 {% endjavascripts %}
 ```
+
+## Release strategy
+
+### CHANGELOG
+The changelog for the bundle is kept in the `./CHANGELOG` file. A history of the releases can be found in this file.
+Previous RMT release notes are kept in this file for history purposes. Please use markdown to style the changelog.  
+
+Please update the changelog with any notable changes that are introduced in an upcoming release. If you are not yet 
+certain what the next release number will be, give the release title a generic value like `Upcoming release`. Make sure
+before merging the changes to the release branch to update the release title in the changelog.
+
+**Example CHANGELOG entry**
+```
+# 2.5.23
+Brief explenation on the major changes of this release
+
+## New features
+ * Title of PR of the new feature #30
+ * Support of POST binding for AuthnRequest #31
+ 
+## Bugfixes
+ * Title of PR of the bugfix #33
+
+## Improvements
+ * Title of PR of the improvement #29
+ 
+```
+
+When releasing a hotfix on a release branch, please update the changelog on the release branch and after releasing the
+hotfix, also merge the hotfix to develop.

--- a/RMT
+++ b/RMT
@@ -1,4 +1,0 @@
-#!/usr/bin/env php
-<?php
-define('RMT_ROOT_DIR', __DIR__);
-require 'vendor/liip/rmt/command.php';

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "guzzlehttp/guzzle": "^6.0",
         "monolog/monolog": "~1.11",
         "sensio/framework-extra-bundle": "~3",
-        "surfnet/stepup-saml-bundle": "dev-feature/specific-error-pages as 3.0.0",
+        "surfnet/stepup-saml-bundle": "^4.0",
         "symfony/config": "^2.7",
         "symfony/dependency-injection": "^2.7",
         "symfony/form": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "guzzlehttp/guzzle": "^6.0",
         "monolog/monolog": "~1.11",
         "sensio/framework-extra-bundle": "~3",
+        "surfnet/stepup-saml-bundle": "dev-feature/specific-error-pages as 3.0.0",
         "symfony/config": "^2.7",
         "symfony/dependency-injection": "^2.7",
         "symfony/form": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cf46b42b9bb08e18478c879bf85c478f",
-    "content-hash": "6d4f1c4a44622d26acd5aaab4dab71dd",
+    "content-hash": "96c207db0a3afcf65a48c652b25a4133",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -73,7 +72,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -143,7 +142,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31 16:37:02"
+            "time": "2015-12-31T16:37:02+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -209,7 +208,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14 22:21:58"
+            "time": "2015-04-14T22:21:58+00:00"
         },
         {
             "name": "doctrine/common",
@@ -282,7 +281,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-12-25 13:18:31"
+            "time": "2015-12-25T13:18:31+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -349,7 +348,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06 14:35:42"
+            "time": "2015-11-06T14:35:42+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -403,7 +402,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "graylog2/gelf-php",
@@ -456,7 +455,7 @@
                 }
             ],
             "description": "A php implementation to send log-messages to a GELF compatible backend like Graylog2.",
-            "time": "2016-06-02 06:04:56"
+            "time": "2016-06-02T06:04:56+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -518,7 +517,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-10-08 15:01:37"
+            "time": "2016-10-08T15:01:37+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -569,7 +568,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-12-20 10:07:11"
+            "time": "2016-12-20T10:07:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -634,7 +633,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-02-21 01:20:32"
+            "time": "2017-02-21T01:20:32+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -676,7 +675,7 @@
                 "hashing",
                 "password"
             ],
-            "time": "2014-11-20 16:49:30"
+            "time": "2014-11-20T16:49:30+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -754,7 +753,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-07-02 14:02:10"
+            "time": "2016-07-02T14:02:10+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -802,7 +801,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-04-03 06:00:07"
+            "time": "2016-04-03T06:00:07+00:00"
         },
         {
             "name": "psr/http-message",
@@ -852,7 +851,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
@@ -890,7 +889,47 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2012-12-21T11:40:51+00:00"
+        },
+        {
+            "name": "robrichards/xmlseclibs",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/robrichards/xmlseclibs.git",
+                "reference": "d937712f70f93a584eb0299ccd87dc6374003781"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/d937712f70f93a584eb0299ccd87dc6374003781",
+                "reference": "d937712f70f93a584eb0299ccd87dc6374003781",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 5.4"
+            },
+            "suggest": {
+                "ext-openssl": "OpenSSL extension"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RobRichards\\XMLSecLibs\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A PHP library for XML Security",
+            "homepage": "https://github.com/robrichards/xmlseclibs",
+            "keywords": [
+                "security",
+                "signature",
+                "xml",
+                "xmldsig"
+            ],
+            "time": "2017-08-31T09:27:07+00:00"
         },
         {
             "name": "sensio/framework-extra-bundle",
@@ -952,7 +991,112 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2016-03-25 17:08:27"
+            "time": "2016-03-25T17:08:27+00:00"
+        },
+        {
+            "name": "simplesamlphp/saml2",
+            "version": "v3.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/simplesamlphp/saml2.git",
+                "reference": "4f6af7f69f29df8555a18b9bb7b646906b45924d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/4f6af7f69f29df8555a18b9bb7b646906b45924d",
+                "reference": "4f6af7f69f29df8555a18b9bb7b646906b45924d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-zlib": "*",
+                "php": ">=5.4",
+                "psr/log": "~1.0",
+                "robrichards/xmlseclibs": "^3.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9",
+                "phpmd/phpmd": "~1.5",
+                "phpunit/phpunit": "~3.7",
+                "sebastian/phpcpd": "~1.4",
+                "sensiolabs/security-checker": "~1.1",
+                "squizlabs/php_codesniffer": "~1.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "v3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "SAML2\\": "src/"
+                },
+                "files": [
+                    "src/_autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Åkre Solberg",
+                    "email": "andreas.solberg@uninett.no"
+                }
+            ],
+            "description": "SAML2 PHP library from SimpleSAMLphp",
+            "time": "2018-03-02T14:30:38+00:00"
+        },
+        {
+            "name": "surfnet/stepup-saml-bundle",
+            "version": "dev-feature/specific-error-pages",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OpenConext/Stepup-saml-bundle.git",
+                "reference": "7f3a9314c1e02bce048d51d9c185c9728b0c4af3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/7f3a9314c1e02bce048d51d9c185c9728b0c4af3",
+                "reference": "7f3a9314c1e02bce048d51d9c185c9728b0c4af3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=5.6,<8.0-dev",
+                "robrichards/xmlseclibs": "^3.0",
+                "simplesamlphp/saml2": "^3.0",
+                "symfony/dependency-injection": ">=2.7,<4",
+                "symfony/framework-bundle": ">=2.7,<4"
+            },
+            "require-dev": {
+                "ibuildings/qa-tools": "~1.1",
+                "liip/rmt": "~1.1",
+                "mockery/mockery": "~0.9",
+                "psr/log": "~1.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Surfnet\\SamlBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "A Symfony2 bundle that integrates the simplesamlphp\\saml2 library with Symfony",
+            "keywords": [
+                "SAML2",
+                "saml",
+                "simplesamlphp",
+                "stepup",
+                "surfnet"
+            ],
+            "time": "2018-03-14T14:27:38+00:00"
         },
         {
             "name": "symfony/asset",
@@ -1007,7 +1151,7 @@
             ],
             "description": "Symfony Asset Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-13 18:03:36"
+            "time": "2016-05-13T18:03:36+00:00"
         },
         {
             "name": "symfony/class-loader",
@@ -1063,7 +1207,7 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/config",
@@ -1116,7 +1260,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:31:50"
+            "time": "2016-06-29T05:31:50+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1173,7 +1317,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:29:29"
+            "time": "2016-06-29T05:29:29+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -1236,7 +1380,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:31:50"
+            "time": "2016-06-29T05:31:50+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1296,7 +1440,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-19 10:44:15"
+            "time": "2016-07-19T10:44:15+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1345,7 +1489,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-20 05:43:46"
+            "time": "2016-07-20T05:43:46+00:00"
         },
         {
             "name": "symfony/finder",
@@ -1394,7 +1538,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/form",
@@ -1468,7 +1612,7 @@
             ],
             "description": "Symfony Form Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:29:29"
+            "time": "2016-06-29T05:29:29+00:00"
         },
         {
             "name": "symfony/framework-bundle",
@@ -1560,7 +1704,7 @@
             ],
             "description": "Symfony FrameworkBundle",
             "homepage": "https://symfony.com",
-            "time": "2016-06-30 11:30:07"
+            "time": "2016-06-30T11:30:07+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -1615,7 +1759,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 07:02:14"
+            "time": "2016-06-29T07:02:14+00:00"
         },
         {
             "name": "symfony/http-kernel",
@@ -1697,7 +1841,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-30 15:42:15"
+            "time": "2016-06-30T15:42:15+00:00"
         },
         {
             "name": "symfony/intl",
@@ -1772,7 +1916,7 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2016-06-29 05:40:45"
+            "time": "2016-06-29T05:40:45+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -1826,7 +1970,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2016-06-29 05:29:29"
+            "time": "2016-06-29T05:29:29+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
@@ -1884,7 +2028,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1943,7 +2087,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-php54",
@@ -2001,7 +2145,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         },
         {
             "name": "symfony/polyfill-php55",
@@ -2057,7 +2201,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -2113,7 +2257,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -2172,7 +2316,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         },
         {
             "name": "symfony/polyfill-util",
@@ -2224,7 +2368,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -2284,7 +2428,7 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/routing",
@@ -2359,7 +2503,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/security-core",
@@ -2425,7 +2569,7 @@
             ],
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/security-csrf",
@@ -2483,7 +2627,7 @@
             ],
             "description": "Symfony Security Component - CSRF Library",
             "homepage": "https://symfony.com",
-            "time": "2016-03-10 10:34:12"
+            "time": "2016-03-10T10:34:12+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -2532,7 +2676,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/templating",
@@ -2587,7 +2731,7 @@
             ],
             "description": "Symfony Templating Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-27 10:24:39"
+            "time": "2016-03-27T10:24:39+00:00"
         },
         {
             "name": "symfony/translation",
@@ -2651,7 +2795,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21 16:59:38"
+            "time": "2017-01-21T16:59:38+00:00"
         },
         {
             "name": "symfony/twig-bridge",
@@ -2732,7 +2876,7 @@
             ],
             "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:29:29"
+            "time": "2016-06-29T05:29:29+00:00"
         },
         {
             "name": "symfony/validator",
@@ -2805,7 +2949,7 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:29:29"
+            "time": "2016-06-29T05:29:29+00:00"
         },
         {
             "name": "twig/twig",
@@ -2866,7 +3010,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-01-11 19:36:15"
+            "time": "2017-01-11T19:36:15+00:00"
         }
     ],
     "packages-dev": [
@@ -2922,7 +3066,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "guzzlehttp/streams",
@@ -2975,7 +3119,7 @@
                 "Guzzle",
                 "stream"
             ],
-            "time": "2014-08-17 21:15:53"
+            "time": "2014-08-17T21:15:53+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -3020,7 +3164,7 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11 14:41:42"
+            "time": "2015-05-11T14:41:42+00:00"
         },
         {
             "name": "liip/rmt",
@@ -3079,7 +3223,7 @@
                 "vcs tag",
                 "version"
             ],
-            "time": "2015-05-06 20:11:13"
+            "time": "2015-05-06T20:11:13+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -3144,7 +3288,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2016-05-22 21:52:33"
+            "time": "2016-05-22T21:52:33+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -3184,7 +3328,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2017-01-19 14:23:36"
+            "time": "2017-01-19T14:23:36+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3238,7 +3382,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -3283,7 +3427,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -3330,7 +3474,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -3396,7 +3540,7 @@
                 "phpmd",
                 "pmd"
             ],
-            "time": "2017-01-20 14:41:10"
+            "time": "2017-01-20T14:41:10+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -3459,7 +3603,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3521,7 +3665,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3568,7 +3712,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -3609,7 +3753,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -3653,7 +3797,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -3702,7 +3846,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-23 06:14:45"
+            "time": "2017-02-23T06:14:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -3774,7 +3918,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06 05:18:07"
+            "time": "2017-02-06T05:18:07+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -3830,7 +3974,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -3894,7 +4038,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -3946,7 +4090,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -3996,7 +4140,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4063,7 +4207,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/finder-facade",
@@ -4102,7 +4246,7 @@
             ],
             "description": "FinderFacade is a convenience wrapper for Symfony's Finder component.",
             "homepage": "https://github.com/sebastianbergmann/finder-facade",
-            "time": "2016-02-17 07:02:23"
+            "time": "2016-02-17T07:02:23+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -4153,7 +4297,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/phpcpd",
@@ -4204,7 +4348,7 @@
             ],
             "description": "Copy/Paste Detector (CPD) for PHP code.",
             "homepage": "https://github.com/sebastianbergmann/phpcpd",
-            "time": "2016-04-17 19:32:49"
+            "time": "2016-04-17T19:32:49+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -4257,7 +4401,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4292,7 +4436,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "sensiolabs/security-checker",
@@ -4337,7 +4481,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2015-05-28 14:22:40"
+            "time": "2015-05-28T14:22:40+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -4412,7 +4556,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-12-04 22:32:15"
+            "time": "2014-12-04T22:32:15+00:00"
         },
         {
             "name": "symfony/console",
@@ -4473,7 +4617,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-06 12:04:06"
+            "time": "2017-02-06T12:04:06+00:00"
         },
         {
             "name": "symfony/process",
@@ -4522,7 +4666,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:29:29"
+            "time": "2016-06-29T05:29:29+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -4571,7 +4715,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21 16:40:50"
+            "time": "2017-01-21T16:40:50+00:00"
         },
         {
             "name": "theseer/fdomdocument",
@@ -4611,7 +4755,7 @@
             ],
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
-            "time": "2015-05-27 22:58:02"
+            "time": "2015-05-27T22:58:02+00:00"
         },
         {
             "name": "vierbergenlars/php-semver",
@@ -4663,7 +4807,7 @@
                 "semver",
                 "versioning"
             ],
-            "time": "2015-05-02 19:28:54"
+            "time": "2015-05-02T19:28:54+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4713,12 +4857,21 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "3.0.0",
+            "alias_normalized": "3.0.0.0",
+            "version": "dev-feature/specific-error-pages",
+            "package": "surfnet/stepup-saml-bundle"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "surfnet/stepup-saml-bundle": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "96c207db0a3afcf65a48c652b25a4133",
+    "content-hash": "cbaa352cdd72706e21cee7c51dc95465",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1052,16 +1052,16 @@
         },
         {
             "name": "surfnet/stepup-saml-bundle",
-            "version": "dev-feature/specific-error-pages",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-saml-bundle.git",
-                "reference": "7f3a9314c1e02bce048d51d9c185c9728b0c4af3"
+                "reference": "9bb7098248c7b60c8b2cbc74d996b027de69e68a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/7f3a9314c1e02bce048d51d9c185c9728b0c4af3",
-                "reference": "7f3a9314c1e02bce048d51d9c185c9728b0c4af3",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/9bb7098248c7b60c8b2cbc74d996b027de69e68a",
+                "reference": "9bb7098248c7b60c8b2cbc74d996b027de69e68a",
                 "shasum": ""
             },
             "require": {
@@ -1096,7 +1096,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2018-03-14T14:27:38+00:00"
+            "time": "2018-03-21T09:35:58+00:00"
         },
         {
             "name": "symfony/asset",
@@ -4860,18 +4860,9 @@
             "time": "2016-11-23T20:04:58+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "3.0.0",
-            "alias_normalized": "3.0.0.0",
-            "version": "dev-feature/specific-error-pages",
-            "package": "surfnet/stepup-saml-bundle"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "surfnet/stepup-saml-bundle": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\EventListener\ExceptionListener as CoreExceptionListener;
+
+/**
+ * Prepare the generic error page with detailed information for the user.
+ */
+class ExceptionListener extends CoreExceptionListener
+{
+    /**
+     * Clones the request for the exception.
+     *
+     * Stepup-specific override: pass the original exception instead of the
+     * FlattenException so we can show very speficic user messages in the
+     * ExceptionController.
+     *
+     * @param \Exception $exception The thrown exception
+     * @param Request    $request   The original request
+     *
+     * @return Request $request The cloned request
+     */
+    protected function duplicateRequest(\Exception $exception, Request $request)
+    {
+        $attributes = array(
+            '_controller' => $this->controller,
+            'exception' => $exception,
+            'logger' => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
+            // keep for BC -- as $format can be an argument of the controller callable
+            // see src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+            // @deprecated since version 2.4, to be removed in 3.0
+            'format' => $request->getRequestFormat(),
+        );
+        $request = $request->duplicate(null, null, $attributes);
+        $request->setMethod('GET');
+
+        return $request;
+    }
+}

--- a/src/Exception/Art.php
+++ b/src/Exception/Art.php
@@ -33,15 +33,6 @@ class Art
     }
 
     /**
-     * @param FlattenException $exception
-     * @return string
-     */
-    public static function forFlattenException(FlattenException $exception)
-    {
-        return self::calculateArt($exception->getClass(), $exception->getMessage());
-    }
-
-    /**
      * @param string $className
      * @param string $message
      * @return string

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -141,6 +141,16 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 
+    surfnet_stepup.listener.exception:
+        class: Surfnet\StepupBundle\EventListener\ExceptionListener
+        arguments:
+            - '%twig.exception_listener.controller%'
+            - '@logger'
+        tags:
+            # It is very important this listener has a priority higher than the default exception listener,
+            # and ideally lower than the profiler listener (so exceptions show up in the toolbar).
+            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: -128 }
+
     surfnet_stepup.locale_cookie_helper:
         class: Surfnet\StepupBundle\Http\CookieHelper
         arguments:

--- a/src/Resources/views/Exception/error.html.twig
+++ b/src/Resources/views/Exception/error.html.twig
@@ -1,14 +1,43 @@
 {% extends '::base.html.twig' %}
 
-{% block page_title %}{{ 'Error' }}{% endblock %}
+{% block page_title %}{{ 'Error - ' ~ title }}{% endblock %}
 
 {% block content %}
-    <h2>{{ block('page_title') }}</h2>
+    <h2>{{ title }}</h2>
 
-    <p>{{ 'A error occurred due to an unknown cause. Go back and try again or go to the homepage.' }}</p>
-    <a class="btn btn-primary" href="/">{{ 'To the homepage' }}</a>
+    <p>{{ description }}</p>
 
-    <hr>
-    <p>{{ 'The error code for the error is' }}: <span class="art">#{{ art }}</span></p>
-    <p>{{ 'If you think this error is a mistake, please report it to SURFnet.' }}</p>
+    <table class="table table-bordered">
+        <tr>
+            <th>{{ 'stepup.error.timestamp'|trans }}</th>
+            <td>{{ timestamp }}</td>
+        </tr>
+        <tr>
+            <th>{{ 'stepup.error.hostname'|trans }}</th>
+            <td>{{ hostname }}</td>
+        </tr>
+        <tr>
+            <th>{{ 'stepup.error.request_id'|trans }}</th>
+            <td>{{ request_id }}</td>
+        </tr>
+        <tr>
+            <th>{{ 'stepup.error.error_code'|trans }}</th>
+            <td>{{ error_code }}</td>
+        </tr>
+        <tr>
+            <th>{{ 'stepup.error.user_agent'|trans }}</th>
+            <td>{{ user_agent }}</td>
+        </tr>
+        <tr>
+            <th>{{ 'stepup.error.ip_address'|trans }}</th>
+            <td>{{ ip_address }}</td>
+        </tr>
+    </table>
+
+    <p>{{ 'stepup.error.support_page.text'|trans({'%support_url%': global_view_parameters.supportUrl })|raw }}</p>
+
+    {% block back_button %}
+        <a class="btn btn-primary" href="/">{{ 'Back' }}</a>
+    {% endblock %}
+
 {% endblock %}

--- a/src/Resources/views/Exception/error404.html.twig
+++ b/src/Resources/views/Exception/error404.html.twig
@@ -1,14 +1,17 @@
 {% extends '::base.html.twig' %}
 
-{% block page_title %}{{ 'Page not found' }}{% endblock %}
+{% block page_title %}{{ 'stepup.error.page_not_found.title'|trans }}{% endblock %}
 
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
 
-    <p>{{ 'The page you requested was not found. Go back to try again or go to the homepage.' }}</p>
-    <a class="btn btn-primary" href="/">{{ 'To the homepage' }}</a>
+    <p>{{ 'stepup.error.page_not_found.text'|trans }}</p>
+
+    {% block back_button %}
+        <a class="btn btn-primary" href="javascript:window.history.go(-1)">{{ 'stepup.error.back_button'|trans}}</a>
+    {% endblock %}
 
     <hr>
-    <p>{{ 'The error code for the error is' }}: <span class="art">#{{ art }}</span></p>
-    <p>{{ 'If you think this error is a mistake, please report it to SURFnet.' }}</p>
+
+    <p>{{ 'stepup.error.support_page.text'|trans({'%support_url%': global_view_parameters.supportUrl })|raw }}</p>
 {% endblock %}


### PR DESCRIPTION
In order for the exception controller to be able to show specific
messages depending on the exception type, it needs access to the
original exception object instead of the FlattenException which the
symfony exception listener passes on to the controller. In order to
make this work, the stepup bundle now overrides the default exception
controller.
