### PR TITLE
Improve art-code algorithm

### DIFF
--- a/src/Exception/Art.php
+++ b/src/Exception/Art.php
@@ -48,6 +48,28 @@ class Art
      */
     private static function calculateArt($className, $message)
     {
-        return substr(abs(crc32(md5($className . $message))), 0, 4);
+        $message = self::stripVariableArgumentsFromMessage($message);
+
+        return substr(abs(crc32(md5($className . $message))), 0, 5);
+    }
+
+    /**
+     * Strip variable arguments from exception messages.
+     *
+     * Some exception messages are formatted using sprintf, and result in a
+     * unique art-code for each distinct message. In order for the art-code to
+     * be useful it must be the same for each distinct error situation without
+     * taking into account variable parts of the message.
+     *
+     * This method strips all strings inside quotes. This is not perfect
+     * because it relies on sprintf arguments to always be quoted inside the
+     * message.
+     *
+     * @param $message
+     * @return string
+     */
+    private static function stripVariableArgumentsFromMessage($message)
+    {
+        return preg_replace('#".*"|\'.*\'#', '', $message);
     }
 }

--- a/src/Tests/Exception/ArtTest.php
+++ b/src/Tests/Exception/ArtTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Tests\Exception;
+
+use Exception;
+use RuntimeException;
+use PHPUnit_Framework_TestCase as UnitTest;
+use Surfnet\StepupBundle\Exception\Art;
+
+class ArtTest extends UnitTest
+{
+    /**
+     * @test
+     * @group art
+     */
+    public function art_code_is_numeric()
+    {
+        $this->assertTrue(is_numeric(Art::forException(new Exception)), 'Expected numeric Art code');
+    }
+
+    /**
+     * @test
+     * @group art
+     */
+    public function art_code_is_distinct_per_exception_type()
+    {
+        $art1 = new Exception();
+        $art2 = new RuntimeException();
+
+        $this->assertNotEquals($art1, $art2, 'Expected different art code for different exception type');
+    }
+
+    /**
+     * @test
+     * @group art
+     */
+    public function art_code_is_distinct_per_message()
+    {
+        $art1 = new Exception('one');
+        $art2 = new Exception('two');
+
+        $this->assertNotEquals($art1, $art2, 'Expected different art code for different exception message');
+    }
+
+    /**
+     * @test
+     * @group art
+     * @dataProvider artCodeWithStrippedVariables
+     *
+     * @param Exception $exception
+     * @param int $expectedArtCode
+     */
+    public function exception_translates_to_art_code_with_variables_stripped(Exception $exception, $expectedArtCode)
+    {
+        $this->assertEquals(
+            $expectedArtCode,
+            Art::forException($exception)
+        );
+    }
+
+    public function artCodeWithStrippedVariables()
+    {
+        $artCode = Art::forException(
+            new Exception('This is a \'good\' message')
+        );
+
+        return [
+            [new Exception('This is a \'nice\' message'), $artCode],
+            [new Exception('This is a "real" message'), $artCode],
+            [new Exception('This is a "re"X"al" message'), $artCode],
+            [new Exception('This is a "re\'X\'al" message'), $artCode],
+            [new Exception('This is a "" message'), $artCode],
+        ];
+    }
+}


### PR DESCRIPTION
The art code is now 5 digits long instead of 4 to minimize the risk of
collisions. And variable parts of exception messages are not taken
into account, for example:

    Unknown entity ID "http://example.org" in request
    Unknown entity ID "http://example.com" in request
    Unknown entity ID "" in request

all result in the same art code.