### PR TITLE
Add shared service and collection from RA

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -153,3 +153,6 @@ services:
     surfnet_stepup.guzzle.handler_stack:
         class: GuzzleHttp\HandlerStack
         factory: ['GuzzleHttp\HandlerStack', create]
+
+    surfnet_stepup.provider.collection:
+        class: Surfnet\StepupBundle\Value\Provider\ViewConfigCollection

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -104,6 +104,12 @@ services:
         arguments:
             - "%enabled_generic_second_factors%"
 
+    surfnet_stepup.service.second_factor_type_translator:
+        class: Surfnet\StepupBundle\Service\SecondFactorTypeTranslationService
+        arguments:
+            - "@surfnet_stepup.provider.collection"
+            - "@translator"
+
     surfnet_stepup.guzzle.gateway_api:
         public: false
         class: GuzzleHttp\Client

--- a/src/Service/SecondFactorTypeTranslationService.php
+++ b/src/Service/SecondFactorTypeTranslationService.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Service;
+
+use Surfnet\StepupBundle\Value\Provider\ViewConfigCollection;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Provide translations for second factor types like yubikey, tiqr, sms, u2f, ..
+ *
+ * Generic tokens (gssp) are translated from the YAML configuration provided for them. Where the hard coded types (sms,
+ * yubikey and u2f) are translated using the Symfony translator.
+ *
+ * Translations should be provided in the translations file for this project and should follow the format specified in
+ * the 'translationIdFormat' field.
+ */
+class SecondFactorTypeTranslationService
+{
+    /**
+     * @var ViewConfigCollection
+     */
+    private $gsspConfigCollection;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(
+        ViewConfigCollection $gsspConfigCollection,
+        TranslatorInterface $translator
+    ) {
+        $this->gsspConfigCollection = $gsspConfigCollection;
+        $this->translator = $translator;
+    }
+
+    /**
+     * @param string $secondFactorTypeId
+     * @param string $translationIdFormat The format used to read a translation from the Symfony translator. Should be
+     *                                    compatible with sprintf. Where one string parameter represents the seconf
+     *                                    factor type. Example 'ra.gssp_token.%s.title'
+     * @return string
+     */
+    public function translate($secondFactorTypeId, $translationIdFormat)
+    {
+        $translationId = sprintf($translationIdFormat, $secondFactorTypeId);
+
+        if ($this->gsspConfigCollection->isGssp($secondFactorTypeId)) {
+            // Attempt a gssp translation based on the gssp config
+            $translation = $this->gsspConfigCollection
+                ->getByIdentifier($secondFactorTypeId)
+                ->getTitle();
+        } else {
+            // Attempt a regular symfony translation for any non gssp sf type.
+            $translation = $this->translator->trans($translationId);
+        }
+
+        // If unable to translate, return the translation id, the user of this translator should decide how to handle
+        // this situation.
+        if ($translationId === $translation) {
+            return $secondFactorTypeId;
+        }
+
+        return $translation;
+    }
+}

--- a/src/Value/Provider/ViewConfigCollection.php
+++ b/src/Value/Provider/ViewConfigCollection.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Value\Provider;
+
+use Surfnet\StepupBundle\Exception\InvalidArgumentException;
+
+/**
+ * Collection of ViewConfig instances. The collection can be used to find ViewConfig objects based on their second
+ * factor type id.
+ */
+class ViewConfigCollection
+{
+    /**
+     * @var ViewConfigInterface[]
+     */
+    private $collection = [];
+
+    /**
+     * @param ViewConfigInterface $viewConfig
+     * @param $identifier
+     */
+    public function addViewConfig(ViewConfigInterface $viewConfig, $identifier)
+    {
+        $this->collection[$identifier] = $viewConfig;
+    }
+
+    /**
+     * @param $identifier
+     * @return ViewConfigInterface
+     * @throws InvalidArgumentException
+     */
+    public function getByIdentifier($identifier)
+    {
+        if (isset($this->collection[$identifier])) {
+            return $this->collection[$identifier];
+        }
+        throw new InvalidArgumentException(
+            sprintf(
+                'The provider identified by "%s" can not be found in the ViewConfigCollection',
+                $identifier
+            )
+        );
+    }
+
+    /**
+     * @param $identifier
+     * @return bool
+     */
+    public function isGssp($identifier)
+    {
+        return isset($this->collection[$identifier]);
+    }
+}

--- a/src/Value/Provider/ViewConfigInterface.php
+++ b/src/Value/Provider/ViewConfigInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Value\Provider;
+
+/**
+ * A marker interface for ViewConfig implementations. Added primarily to be able to collect them in the
+ * ViewConfigCollection
+ */
+interface ViewConfigInterface
+{
+}


### PR DESCRIPTION
The SecondFactorTypeTranslationService and the ViewConfigCollection classes where created in RA context but can be perfectly used in SS too. This PR moves these files to the Stepup-bundle.

Corresponding RA [pull request#149](https://github.com/OpenConext/Stepup-RA/pull/149)
Corresponding SS [pull request#138](https://github.com/OpenConext/Stepup-SelfService/pull/138)