### PR TITLE
Add experimental support for symfony 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         "monolog/monolog": "~1.11",
         "sensio/framework-extra-bundle": "~3",
         "surfnet/stepup-saml-bundle": "^4.0",
-        "symfony/config": "^2.7",
-        "symfony/dependency-injection": "^2.7",
-        "symfony/form": "^2.7",
-        "symfony/framework-bundle": "^2.7",
-        "symfony/http-kernel": "^2.7",
-        "symfony/twig-bridge": "^2.7",
-        "symfony/validator": "^2.7"
+        "symfony/config": ">=2.7,<4",
+        "symfony/dependency-injection": ">=2.7,<4",
+        "symfony/form": ">=2.7,<4",
+        "symfony/framework-bundle": ">=2.7,<4",
+        "symfony/http-kernel": ">=2.7,<4",
+        "symfony/twig-bridge": ">=2.7,<4",
+        "symfony/validator": ">=2.7,<4"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",

--- a/src/Monolog/Processor/ArtProcessor.php
+++ b/src/Monolog/Processor/ArtProcessor.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupBundle\Monolog\Processor;
 
+use Exception;
 use Surfnet\StepupBundle\Exception\Art;
 
 class ArtProcessor
@@ -29,6 +30,13 @@ class ArtProcessor
     public function __invoke(array $record)
     {
         if (!isset($record['context']['exception'])) {
+            return $record;
+        }
+
+        // Symfony 3 triggers this processor with SilencedErrorContext objects
+        // in case of PHP errors (deprecation notices, errors, etc). We should
+        // only generate Art codes for exceptions.
+        if (!$record['context']['exception'] instanceof Exception) {
             return $record;
         }
 


### PR DESCRIPTION
Only the dependency constraints are loosened to allow usage in
combination with symfony 3. This is experimental and intended to allow
usage of logging and error handling components in Stepup-tiqr.