### PR TITLE
Provide a SmsSecondFactorService test double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.2
+Provide a test double for the SmsSecondFactorService
+
 # 4.0.1
 Remove the choice list feature from the CountryCodeListing value object as this interferes with the Symfony 3.4 way
 of working with choice types.

--- a/src/Service/SmsSecondFactorService.php
+++ b/src/Service/SmsSecondFactorService.php
@@ -25,7 +25,7 @@ use Surfnet\StepupBundle\Exception\InvalidArgumentException;
 use Surfnet\StepupBundle\Service\SmsSecondFactor\OtpVerification;
 use Surfnet\StepupBundle\Service\SmsSecondFactor\SmsVerificationStateHandler;
 
-class SmsSecondFactorService
+class SmsSecondFactorService implements SmsSecondFactorServiceInterface
 {
     /**
      * @var \Surfnet\StepupBundle\Service\SmsService

--- a/src/Service/SmsSecondFactorServiceInterface.php
+++ b/src/Service/SmsSecondFactorServiceInterface.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Service;
+
+use Surfnet\StepupBundle\Command\SendSmsChallengeCommand;
+use Surfnet\StepupBundle\Command\VerifyPossessionOfPhoneCommand;
+use Surfnet\StepupBundle\Service\SmsSecondFactor\OtpVerification;
+
+interface SmsSecondFactorServiceInterface
+{
+    /**
+     * The remaining number of requests as an integer value.
+     * @return int
+     */
+    public function getOtpRequestsRemainingCount();
+
+    /**
+     * Return the number of OTP requests that can be taken as an integer value.
+     * @return int
+     */
+    public function getMaximumOtpRequestsCount();
+
+    /**
+     * Tests if this session has made prior requests
+     * @return bool
+     */
+    public function hasSmsVerificationState();
+
+    /**
+     * Clears the verification state, forget this user has performed SMS requests.
+     * @return mixed
+     */
+    public function clearSmsVerificationState();
+
+    /**
+     * Send an SMS OTP challenge
+     *
+     * This challenge gets sent to the recipient whose information can be found in the SendSmsChallengeCommand.
+     * This method will return a boolean which indicates if the challenge was sent successfully.
+     *
+     * When the MaximumOtpRequestsCount is reached, this method should throw the TooManyChallengesRequestedException
+     *
+     * @param SendSmsChallengeCommand $command
+     * @return bool
+     */
+    public function sendChallenge(SendSmsChallengeCommand $command);
+
+    /**
+     * Verify the SMS OTP
+     *
+     * Proving possession by verifying the OTP, the recipient received and typed in a web form, matches the OTP that was
+     * sent. Various results can be returned in the form of a ProofOfPossessionResult.
+     *
+     * @param VerifyPossessionOfPhoneCommand $challengeCommand
+     * @return OtpVerification
+     */
+    public function verifyPossession(VerifyPossessionOfPhoneCommand $command);
+}

--- a/src/Tests/TestDouble/Service/SmsSecondFactorService.php
+++ b/src/Tests/TestDouble/Service/SmsSecondFactorService.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Tests\TestDouble\Service;
+
+use Surfnet\StepupBundle\Command\SendSmsChallengeCommand;
+use Surfnet\StepupBundle\Command\VerifyPossessionOfPhoneCommand;
+use Surfnet\StepupBundle\Service\SmsSecondFactor\OtpVerification;
+use Surfnet\StepupBundle\Service\SmsSecondFactor\SmsVerificationStateHandler;
+use Surfnet\StepupBundle\Service\SmsSecondFactorServiceInterface;
+
+class SmsSecondFactorService implements SmsSecondFactorServiceInterface
+{
+    /**
+     * @var \Surfnet\StepupBundle\Service\SmsSecondFactor\SmsVerificationStateHandler
+     */
+    private $smsVerificationStateHandler;
+
+    /**
+     * @param SmsVerificationStateHandler $smsVerificationStateHandler
+     */
+    public function __construct(SmsVerificationStateHandler $smsVerificationStateHandler)
+    {
+        $this->smsVerificationStateHandler = $smsVerificationStateHandler;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOtpRequestsRemainingCount()
+    {
+        return 3;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaximumOtpRequestsCount()
+    {
+        return 3;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasSmsVerificationState()
+    {
+        return false;
+    }
+
+    public function clearSmsVerificationState()
+    {
+        // NOOP
+    }
+
+    /**
+     * @param SendSmsChallengeCommand $command
+     * @return bool
+     */
+    public function sendChallenge(SendSmsChallengeCommand $command)
+    {
+        return true;
+    }
+
+    /**
+     * @param VerifyPossessionOfPhoneCommand $command
+     * @return OtpVerification
+     */
+    public function verifyPossession(VerifyPossessionOfPhoneCommand $command)
+    {
+        return OtpVerification::foundMatch('+31 (0) 612345678');
+    }
+}


### PR DESCRIPTION
This test double is used by RA to verify the possession of the users
phone. The service is also provided with an interface. To allow safe
usage of implementations of the service when using DI.