### PR TITLE
Force upgrade of Stepup-saml-bundle to version 4.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.0.4
+This is a security release that will harden the application using this bundle against CVE 2019-3465
+ * Upgrade Stepup-saml-bundle to version 4.1.8 #57
+ * Get the Travis code quality checks to pass again #58
+
 # 4.0.3
 Update Symfony From version restraints
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle": "^6.0",
         "monolog/monolog": "~1.11",
         "sensio/framework-extra-bundle": "~3",
-        "surfnet/stepup-saml-bundle": "^4.0",
+        "surfnet/stepup-saml-bundle": "^4.1.8",
         "symfony/config": ">=2.7,<4",
         "symfony/dependency-injection": ">=2.7,<4",
         "symfony/form": "~2.7|~2.8|~3,4",


### PR DESCRIPTION
This to harden against CVE 2019-3465, this version bump effectively updates robrichards/xmlseclibs to version 3.0.4