### PR TITLE
Get the Travis code quality checks to pass again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,8 @@ branches:
   only:
     - master
     - develop
+
+addons:
+  apt:
+    packages:
+      - ant

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 before_script:
   - phpenv config-add .travis.php.ini
   - composer self-update
-  - composer install --prefer-dist
+  - COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist
 
 script:
   - ant

--- a/src/Monolog/Processor/ApplicationNameProcessor.php
+++ b/src/Monolog/Processor/ApplicationNameProcessor.php
@@ -18,6 +18,8 @@
 
 namespace Surfnet\StepupBundle\Monolog\Processor;
 
+use InvalidArgumentException;
+
 class ApplicationNameProcessor
 {
     /**
@@ -31,7 +33,7 @@ class ApplicationNameProcessor
     public function __construct($applicationName)
     {
         if (!is_string($applicationName)) {
-            throw new \InvalidArgumentException('Application name must be string');
+            throw new InvalidArgumentException('Application name must be string');
         }
 
         $this->applicationName = $applicationName;

--- a/src/Request/JsonConvertibleParamConverter.php
+++ b/src/Request/JsonConvertibleParamConverter.php
@@ -42,6 +42,9 @@ class JsonConvertibleParamConverter implements ParamConverterInterface
         $this->validator = $validator;
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.MissingImport) - Unable to import the dynamic class creation at line 63
+     */
     public function apply(Request $request, ParamConverter $configuration)
     {
         $name = $configuration->getName();

--- a/src/Request/RequestId.php
+++ b/src/Request/RequestId.php
@@ -18,6 +18,8 @@
 
 namespace Surfnet\StepupBundle\Request;
 
+use LogicException;
+
 /**
  * Exposes the current request ID. The request ID identifies all request/response cycles involved in a single
  * user/client interaction.
@@ -70,7 +72,7 @@ class RequestId
     public function set($requestId, $allowOverwrite = false)
     {
         if ($this->requestId !== null && !$allowOverwrite) {
-            throw new \LogicException('May not overwrite request ID.');
+            throw new LogicException('May not overwrite request ID.');
         }
 
         $this->requestId = $requestId;


### PR DESCRIPTION
1. Ant is no longer installed by default on the Travis platform. An explicit installtion instruction was added to achieve installation.
2. Composer ran out of memmory while performing it's install sequence
3. The newer PHPMD version contains new sniffs for missing import statements. They are addressed in the third commit.

A bit of a hodgepodge PR this..