### PR TITLE
Changes for remote vetting

### DIFF
--- a/src/Resources/views/Exception/error.html.twig
+++ b/src/Resources/views/Exception/error.html.twig
@@ -36,8 +36,6 @@
         </tr>
     </table>
 
-    <p>{{ 'stepup.error.support_page.text'|trans({'%support_url%': global_view_parameters.supportUrl })|raw }}</p>
-
     {# For now the back button is not shown on the error page until a more intelligent solution is thought of #}
     {% block back_button %}{% endblock %}
 


### PR DESCRIPTION
Fix error page help link which isn't available and throws an exception on the error page.