### PR TITLE
Deprecate and remove U2F support

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -30,6 +30,8 @@
     <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable" />
         <exclude name="LongVariable" />
+        <exclude name="LongClassName" />
+        <exclude name="ShortClassName" />
     </rule>
 
 </ruleset>

--- a/src/Service/SecondFactorTypeService.php
+++ b/src/Service/SecondFactorTypeService.php
@@ -32,7 +32,6 @@ class SecondFactorTypeService
     private $loaLevelTypeMap = [
         'sms' => Loa::LOA_2,
         'yubikey' => Loa::LOA_3,
-        'u2f' => Loa::LOA_3,
     ];
 
     /**

--- a/src/Service/SecondFactorTypeTranslationService.php
+++ b/src/Service/SecondFactorTypeTranslationService.php
@@ -22,10 +22,10 @@ use Surfnet\StepupBundle\Value\Provider\ViewConfigCollection;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
- * Provide translations for second factor types like yubikey, tiqr, sms, u2f, ..
+ * Provide translations for second factor types like yubikey, tiqr, sms,..
  *
- * Generic tokens (gssp) are translated from the YAML configuration provided for them. Where the hard coded types (sms,
- * yubikey and u2f) are translated using the Symfony translator.
+ * Generic tokens (gssp) are translated from the YAML configuration provided for them. Where the hard coded types (sms
+ * and yubikey) are translated using the Symfony translator.
  *
  * Translations should be provided in the translations file for this project and should follow the format specified in
  * the 'translationIdFormat' field.

--- a/src/Tests/Service/SecondFactorTypeServiceTest.php
+++ b/src/Tests/Service/SecondFactorTypeServiceTest.php
@@ -46,7 +46,6 @@ class SecondFactorTypeServiceTest extends TestCase
         $this->assertContains('biometric', $types);
         $this->assertContains('sms', $types);
         $this->assertContains('yubikey', $types);
-        $this->assertContains('u2f', $types);
     }
 
     /**
@@ -55,7 +54,6 @@ class SecondFactorTypeServiceTest extends TestCase
     public function testGetLevel()
     {
         $service = new SecondFactorTypeService($this->getAvailableSecondFactorTypes());
-        $this->assertEquals(3, $service->getLevel(new SecondFactorType('u2f')));
         $this->assertEquals(2, $service->getLevel(new SecondFactorType('sms')));
     }
 
@@ -82,7 +80,6 @@ class SecondFactorTypeServiceTest extends TestCase
         $this->assertIsArray($types);
         $this->assertContains('sms', $types);
         $this->assertContains('yubikey', $types);
-        $this->assertContains('u2f', $types);
     }
 
     /**

--- a/src/Tests/Value/SecondFactorTypeTest.php
+++ b/src/Tests/Value/SecondFactorTypeTest.php
@@ -30,7 +30,6 @@ final class SecondFactorTypeTest extends TestCase
             'sms' => ['sms'],
             'tiqr' => ['tiqr'],
             'yubikey' => ['yubikey'],
-            'u2f' => ['u2f'],
             'biometric' => ['biometric'],
         ];
     }
@@ -75,6 +74,5 @@ final class SecondFactorTypeTest extends TestCase
     {
         $this->assertTrue((new SecondFactorType('sms'))->isSms());
         $this->assertTrue((new SecondFactorType('yubikey'))->isYubikey());
-        $this->assertTrue((new SecondFactorType('u2f'))->isU2f());
     }
 }

--- a/src/Value/SecondFactorType.php
+++ b/src/Value/SecondFactorType.php
@@ -66,6 +66,7 @@ final class SecondFactorType implements JsonSerializable
 
     /**
      * @return bool
+     * @deprecated u2f support is removed from StepUp in favour of the WebAuthn GSSP
      */
     public function isU2f()
     {


### PR DESCRIPTION
The public function on the SecondFactorType is deprecated, but
other more generic support for u2f is removed from the bundle