### PR TITLE
Add support for self-asserted token registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /cache.properties
 composer.lock
 .idea
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ branches:
     - /^hotfix\/(.*)$/
     - /^bugfix\/(.*)$/
 
+dist: bionic
+
 addons:
   apt:
     packages:

--- a/src/Command/SendRecoveryTokenSmsChallengeCommand.php
+++ b/src/Command/SendRecoveryTokenSmsChallengeCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2014 SURFnet bv
+ * Copyright 2022 SURFnet bv
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ namespace Surfnet\StepupBundle\Command;
 
 use Surfnet\StepupBundle\Value\PhoneNumber\InternationalPhoneNumber;
 
-class SendSmsChallengeCommand
+class SendRecoveryTokenSmsChallengeCommand
 {
     /**
      * @var InternationalPhoneNumber
@@ -30,7 +30,7 @@ class SendSmsChallengeCommand
     /**
      * @var string
      */
-    public $secondFactorId;
+    public $recoveryTokenId;
 
     /**
      * @var string The SMS contents. '%challenge%' will be replaced with the generated OTP.

--- a/src/Command/VerifyPossessionOfPhoneForRecoveryTokenCommand.php
+++ b/src/Command/VerifyPossessionOfPhoneForRecoveryTokenCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Command;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class VerifyPossessionOfPhoneForRecoveryTokenCommand
+{
+    /**
+     * @Assert\NotBlank(message="stepup.verify_possession_of_phone_command.challenge.may_not_be_empty")
+     * @Assert\Type(type="string", message="stepup.verify_possession_of_phone_command.challenge.must_be_string")
+     *
+     * @var string
+     */
+    public $challenge;
+
+    /**
+     * @Assert\Type(type="string", message="stepup.verify_possession_of_phone_command.recovery_token_id.must_be_string")
+     * @var string
+     */
+    public $recoveryTokenId;
+}

--- a/src/DependencyInjection/SurfnetStepupExtension.php
+++ b/src/DependencyInjection/SurfnetStepupExtension.php
@@ -24,6 +24,7 @@ use Surfnet\StepupBundle\Form\ChoiceList\LocaleChoiceList;
 use Surfnet\StepupBundle\Http\CookieHelper;
 use Surfnet\StepupBundle\Service\LoaResolutionService;
 use Surfnet\StepupBundle\Service\SecondFactorTypeService;
+use Surfnet\StepupBundle\Service\SmsRecoveryTokenService;
 use Surfnet\StepupBundle\Service\SmsSecondFactorService;
 use Surfnet\StepupBundle\Value\Loa;
 use Symfony\Component\Config\Definition\Processor;
@@ -160,16 +161,18 @@ class SurfnetStepupExtension extends Extension
     private function configureSmsSecondFactorServices(array $config, ContainerBuilder $container)
     {
         $smsSecondFactorService = $container->getDefinition('surfnet_stepup.service.sms_second_factor');
+        $smsSecondFactorService->replaceArgument(0, new Reference($config['sms']['service']));
         $smsSecondFactorService->replaceArgument(2, $config['sms']['originator']);
+
+        $recoveryTokenService = $container->getDefinition(SmsRecoveryTokenService::class);
+        $recoveryTokenService->replaceArgument(0, new Reference($config['sms']['service']));
+        $recoveryTokenService->replaceArgument(2, $config['sms']['originator']);
 
         $container
             ->getDefinition('surfnet_stepup.service.challenge_handler')
             ->replaceArgument(2, $config['sms']['otp_expiry_interval'])
             ->replaceArgument(3, $config['sms']['maximum_otp_requests']);
 
-        $container
-            ->getDefinition('surfnet_stepup.service.sms_second_factor')
-            ->replaceArgument(0, new Reference($config['sms']['service']));
     }
 
     private function configureLocaleSelectionWidget(array $loaDefinitions, ContainerBuilder $container)

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -106,6 +106,12 @@ services:
     Surfnet\StepupBundle\Service\SmsSecondFactorService:
         alias: surfnet_stepup.service.sms_second_factor
 
+    Surfnet\StepupBundle\Service\SmsRecoveryTokenService:
+        arguments:
+            - '' # SMS service set in extension
+            - "@surfnet_stepup.service.challenge_handler"
+            - '' # Originator set in extension
+
     surfnet_stepup.service.challenge_handler:
         public: false
         class: Surfnet\StepupBundle\Service\SmsSecondFactor\SessionSmsVerificationStateHandler

--- a/src/Service/SmsRecoveryTokenService.php
+++ b/src/Service/SmsRecoveryTokenService.php
@@ -22,6 +22,7 @@ use Surfnet\StepupBundle\Command\SendRecoveryTokenSmsChallengeCommand;
 use Surfnet\StepupBundle\Command\SendSmsChallengeCommand;
 use Surfnet\StepupBundle\Command\SendSmsCommand;
 use Surfnet\StepupBundle\Command\VerifyPossessionOfPhoneCommand;
+use Surfnet\StepupBundle\Command\VerifyPossessionOfPhoneForRecoveryTokenCommand;
 use Surfnet\StepupBundle\Exception\InvalidArgumentException;
 use Surfnet\StepupBundle\Service\SmsSecondFactor\OtpVerification;
 use Surfnet\StepupBundle\Service\SmsSecondFactor\SmsVerificationStateHandler;
@@ -105,8 +106,8 @@ class SmsRecoveryTokenService
         return $this->smsService->sendSms($smsCommand);
     }
 
-    public function verifyPossession(VerifyPossessionOfPhoneCommand $command): OtpVerification
+    public function verifyPossession(VerifyPossessionOfPhoneForRecoveryTokenCommand $command): OtpVerification
     {
-        return $this->smsVerificationStateHandler->verify($command->challenge, $command->secondFactorId);
+        return $this->smsVerificationStateHandler->verify($command->challenge, $command->recoveryTokenId);
     }
 }

--- a/src/Service/SmsRecoveryTokenService.php
+++ b/src/Service/SmsRecoveryTokenService.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupBundle\Service;
+
+use Surfnet\StepupBundle\Command\SendRecoveryTokenSmsChallengeCommand;
+use Surfnet\StepupBundle\Command\SendSmsChallengeCommand;
+use Surfnet\StepupBundle\Command\SendSmsCommand;
+use Surfnet\StepupBundle\Command\VerifyPossessionOfPhoneCommand;
+use Surfnet\StepupBundle\Exception\InvalidArgumentException;
+use Surfnet\StepupBundle\Service\SmsSecondFactor\OtpVerification;
+use Surfnet\StepupBundle\Service\SmsSecondFactor\SmsVerificationStateHandler;
+
+class SmsRecoveryTokenService
+{
+    /**
+     * @var \Surfnet\StepupBundle\Service\SmsService
+     */
+    private $smsService;
+
+    /**
+     * @var \Surfnet\StepupBundle\Service\SmsSecondFactor\SmsVerificationStateHandler
+     */
+    private $smsVerificationStateHandler;
+
+    /**
+     * @var string
+     */
+    private $originator;
+
+    /**
+     * @param SmsService                  $smsService
+     * @param SmsVerificationStateHandler $smsVerificationStateHandler
+     * @param string                      $originator
+     */
+    public function __construct(
+        SmsService $smsService,
+        SmsVerificationStateHandler $smsVerificationStateHandler,
+        $originator
+    ) {
+        if (!is_string($originator)) {
+            throw InvalidArgumentException::invalidType('string', 'originator', $originator);
+        }
+
+        if (!preg_match('~^[a-z0-9]{1,11}$~i', $originator)) {
+            throw new InvalidArgumentException(
+                'Invalid SMS originator given: may only contain alphanumerical characters.'
+            );
+        }
+
+        $this->smsService = $smsService;
+        $this->smsVerificationStateHandler = $smsVerificationStateHandler;
+        $this->originator = $originator;
+    }
+
+    public function getOtpRequestsRemainingCount(string $recoveryTokenId): int
+    {
+        return $this->smsVerificationStateHandler->getOtpRequestsRemainingCount($recoveryTokenId);
+    }
+
+    public function getMaximumOtpRequestsCount(): int
+    {
+        return $this->smsVerificationStateHandler->getMaximumOtpRequestsCount();
+    }
+
+    public function hasSmsVerificationState(string $recoveryTokenId): bool
+    {
+        return $this->smsVerificationStateHandler->hasState($recoveryTokenId);
+    }
+
+    public function clearSmsVerificationState(string $recoveryTokenId)
+    {
+        $this->smsVerificationStateHandler->clearState($recoveryTokenId);
+    }
+
+    public function sendChallenge(SendRecoveryTokenSmsChallengeCommand $command): bool
+    {
+        $challenge = $this->smsVerificationStateHandler->requestNewOtp(
+            (string) $command->phoneNumber,
+            $command->recoveryTokenId)
+        ;
+
+        $smsCommand = new SendSmsCommand();
+        $smsCommand->recipient = $command->phoneNumber->toMSISDN();
+        $smsCommand->originator = $this->originator;
+        $smsCommand->body = str_replace('%challenge%', $challenge, $command->body);
+        $smsCommand->identity = $command->identity;
+        $smsCommand->institution = $command->institution;
+
+        return $this->smsService->sendSms($smsCommand);
+    }
+
+    public function verifyPossession(VerifyPossessionOfPhoneCommand $command): OtpVerification
+    {
+        return $this->smsVerificationStateHandler->verify($command->challenge, $command->secondFactorId);
+    }
+}


### PR DESCRIPTION
- A service tasked with SMS actions for Recovery Tokens was created
- A verification command was added to handle proof of possession of a SMS recovery token.

https://www.pivotaltracker.com/story/show/181934012